### PR TITLE
Fix conflict in required dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.16.2
+numpy==1.15.2
 lalsuite==6.49
 gwpy==0.14.2
 PyCBC==1.13.5

--- a/setup.md
+++ b/setup.md
@@ -6,6 +6,8 @@ All tutorials are Python-based Jupyter notebooks. The instructions below explain
 
 <img src='https://www.wispresort.com/uploadedImages/Winter/easy.png' width=20 /> Easy (No software installation; Works for any OS)
 
+Note: this option will no longer be available starting in January 2020 
+
 You can open any notebook in the Google Co-labs.
 
 1) Visit https://colab.research.google.com
@@ -16,7 +18,9 @@ You can open any notebook in the Google Co-labs.
 
 4) Double click the notebook of your choice
 
-5) At the top of the notebook, there are 2 lines to install the needed Python modules
+5) Select 'Runtime>Change Runtime Type' on the toolbar and ensure that 'Runtime type' is set to Python2
+
+6) At the top of the notebook, there are 2 lines to install the needed Python modules
 
 `! wget -q https://raw.githubusercontent.com/gw-odw/odw-2019/master/requirements.txt -O requirements.txt` <br/>
 `! pip install -q -r ./requirements.txt`

--- a/setup.md
+++ b/setup.md
@@ -18,7 +18,7 @@ You can open any notebook in the Google Co-labs.
 
 4) Double click the notebook of your choice
 
-5) Select 'Runtime>Change Runtime Type' on the toolbar and ensure that 'Runtime type' is set to Python2
+5) Select 'Runtime>Change Runtime Type' on the toolbar and ensure that 'Runtime type' is set to Python 2
 
 6) At the top of the notebook, there are 2 lines to install the needed Python modules
 


### PR DESCRIPTION
This pull request fixes a conflict in the required dependencies for numpy. With this change, the example notebooks all run to completion. 

This pull request also adds lines to the setup instructions to address changes in Google Colabs. An additional step is added to ensure that the user is running Python 2, as the default python version for Colabs notebooks has switched to Python 3. A note has also been added addressing the fact that Google Colabs will no longer support Python 2 notebooks starting January 2020. At that point, this option will no longer be functional. 